### PR TITLE
fix: fetching git tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
 
       - name: Prepare repository
         run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git fetch --prune --unshallow
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @remusao/auto-config@1.0.1-canary.3.53e236f.0
  npm install @remusao/trie@1.0.2-canary.3.53e236f.0
  # or 
  yarn add @remusao/auto-config@1.0.1-canary.3.53e236f.0
  yarn add @remusao/trie@1.0.2-canary.3.53e236f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
