### PR TITLE
internal: make use of custom auto config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Bootstrap
+        run: yarn bootstrap
+
+      - name: Build
+        run: yarn build
+
+      - name: Bundle
+        run: yarn bundle
+
+      - name: Lint
+        run: yarn lint
+
       - name: Create release
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          yarn bootstrap
-          yarn build
-          yarn bundle
-          yarn lint
           yarn release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "release": "auto shipit"
   },
   "devDependencies": {
+    "@remusao/auto-config": "^1.1.0",
     "auto": "^9.9.0",
     "lerna": "^3.20.2"
   },
@@ -31,82 +32,6 @@
     "arrowParens": "always"
   },
   "auto": {
-    "plugins": [
-      "npm",
-      "released"
-    ],
-    "labels": [
-      {
-        "name": "PR: Breaking Change :boom:",
-        "description": "Increment major version when merged",
-        "changelogTitle": ":boom: Breaking Change",
-        "releaseType": "major",
-        "overwrite": true,
-        "color": "#e2372b"
-      },
-      {
-        "name": "PR: New Feature :rocket:",
-        "description": "Increment minor version when merged",
-        "changelogTitle": ":rocket: New Feature",
-        "releaseType": "minor",
-        "overwrite": true,
-        "color": "#2e449b"
-      },
-      {
-        "name": "PR: Performance :running_woman:",
-        "description": "Increment minor version when merged",
-        "changelogTitle": ":running_woman: Performance",
-        "releaseType": "minor",
-        "overwrite": true,
-        "color": "#ead99f"
-      },
-      {
-        "name": "PR: Bug Fix :bug:",
-        "description": "Increment patch version when merged",
-        "changelogTitle": ":bug: Bug Fix",
-        "releaseType": "patch",
-        "overwrite": true,
-        "color": "#56dd97"
-      },
-      {
-        "name": "PR: Polish :nail_care:",
-        "description": "Increment patch version when merged",
-        "changelogTitle": ":nail_care: Polish",
-        "releaseType": "patch",
-        "overwrite": true,
-        "color": "#a9bbe8"
-      },
-      {
-        "name": "PR: Internal :house:",
-        "description": "Changes only affect internals",
-        "changelogTitle": ":house: Internal",
-        "releaseType": "none",
-        "overwrite": true,
-        "color": "#5b1482"
-      },
-      {
-        "name": "PR: Docs :memo:",
-        "description": "Changes only affect documentation",
-        "changelogTitle": ":memo: Documentation",
-        "releaseType": "none",
-        "overwrite": true,
-        "color": "#d2f28a"
-      },
-      {
-        "name": "skip-release",
-        "description": "Preserve the current version when merged",
-        "releaseType": "skip",
-        "overwrite": true,
-        "color": "#e069cf"
-      },
-      {
-        "name": "PR: Dependencies :nut_and_bolt:",
-        "description": "Changes only update dependencies",
-        "changelogTitle": ":nut_and_bolt: Dependencies",
-        "releaseType": "none",
-        "overwrite": true,
-        "color": "#5dbdcc"
-      }
-    ]
+    "extends": "@remusao/auto-config"
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @remusao/auto-config@1.1.1-canary.4.feaa199.0
  npm install @remusao/trie@1.1.1-canary.4.feaa199.0
  # or 
  yarn add @remusao/auto-config@1.1.1-canary.4.feaa199.0
  yarn add @remusao/trie@1.1.1-canary.4.feaa199.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
