### PR TITLE
Only trigger release workflow on pull_request or master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: ["master"]
 
 jobs:
   release:


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @remusao/auto-config@1.1.1-canary.6.eb383dfe3d1ffacd974e862994d21e691818e349.0
  npm install @remusao/thunderbird-msg-filters@1.2.1-canary.6.eb383dfe3d1ffacd974e862994d21e691818e349.0
  npm install @remusao/trie@1.1.1-canary.6.eb383dfe3d1ffacd974e862994d21e691818e349.0
  # or 
  yarn add @remusao/auto-config@1.1.1-canary.6.eb383dfe3d1ffacd974e862994d21e691818e349.0
  yarn add @remusao/thunderbird-msg-filters@1.2.1-canary.6.eb383dfe3d1ffacd974e862994d21e691818e349.0
  yarn add @remusao/trie@1.1.1-canary.6.eb383dfe3d1ffacd974e862994d21e691818e349.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
