### PR TITLE
Fix name and email in auto config

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "arrowParens": "always"
   },
   "auto": {
-    "extends": "@remusao/auto-config"
+    "extends": "@remusao/auto-config",
+    "name": "Rémi Berson",
+    "email": "remi@cliqz.com"
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @remusao/auto-config@1.1.1-canary.7.b5f45dab41ff14bdc72d6d62fe635559b0b7e1c0.0
  npm install @remusao/thunderbird-msg-filters@1.2.1-canary.7.b5f45dab41ff14bdc72d6d62fe635559b0b7e1c0.0
  npm install @remusao/trie@1.1.1-canary.7.b5f45dab41ff14bdc72d6d62fe635559b0b7e1c0.0
  # or 
  yarn add @remusao/auto-config@1.1.1-canary.7.b5f45dab41ff14bdc72d6d62fe635559b0b7e1c0.0
  yarn add @remusao/thunderbird-msg-filters@1.2.1-canary.7.b5f45dab41ff14bdc72d6d62fe635559b0b7e1c0.0
  yarn add @remusao/trie@1.1.1-canary.7.b5f45dab41ff14bdc72d6d62fe635559b0b7e1c0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
