### PR TITLE
Use Map instead of array for trie to lower memory usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "tsc --build ./tsconfig.project.json",
     "bundle": "lerna run bundle",
     "test": "lerna run --concurrency 1 test",
+    "pretest": "yarn build",
     "clean": "lerna run --parallel clean && lerna clean --yes",
     "release": "auto shipit"
   },

--- a/packages/counter/index.test.ts
+++ b/packages/counter/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { Counter } from '.';
+import { Counter } from './index';
 
 describe('@remusao/counter', () => {
   describe('#constructor', () => {

--- a/packages/counter/tsconfig.json
+++ b/packages/counter/tsconfig.json
@@ -5,8 +5,8 @@
     "outDir": "dist/cjs",
     "declarationDir": "dist/types"
   },
-  "include": [
-    "index.ts",
-    "index.test.ts"
+  "files": [
+    "./index.ts",
+    "./index.test.ts"
   ]
 }

--- a/packages/smaz-benchmarks/tsconfig.json
+++ b/packages/smaz-benchmarks/tsconfig.json
@@ -3,7 +3,7 @@
   "references": [
     { "path": "../smaz/tsconfig.json" }
   ],
-  "include": [
-    "index.ts"
+  "files": [
+    "./index.ts"
   ]
 }

--- a/packages/smaz-compress/index.test.ts
+++ b/packages/smaz-compress/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { SmazCompress } from '.';
+import { SmazCompress } from './index';
 
 describe('@remusao/smaz-compress', () => {
   it('compresses empty string', () => {

--- a/packages/smaz-compress/index.ts
+++ b/packages/smaz-compress/index.ts
@@ -28,7 +28,7 @@ export class SmazCompress {
       let root: Trie | undefined = this.trie;
 
       for (let j = inputIndex; j < str.length; j += 1) {
-        root = root.chars[str.charCodeAt(j)];
+        root = root.chars.get(str.charCodeAt(j));
         if (root === undefined) {
           break;
         }
@@ -80,7 +80,7 @@ export class SmazCompress {
       let root: Trie | undefined = this.trie;
 
       for (let j = inputIndex; j < len; j += 1) {
-        root = root.chars[str.charCodeAt(j)];
+        root = root.chars.get(str.charCodeAt(j));
         if (root === undefined) {
           break;
         }

--- a/packages/smaz-compress/tsconfig.json
+++ b/packages/smaz-compress/tsconfig.json
@@ -8,8 +8,8 @@
   "references": [
     { "path": "../trie/tsconfig.json" }
   ],
-  "include": [
-    "index.ts",
-    "index.test.ts"
+  "files": [
+    "./index.ts",
+    "./index.test.ts"
   ]
 }

--- a/packages/smaz-decompress/index.test.ts
+++ b/packages/smaz-decompress/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { SmazDecompress } from '.';
+import { SmazDecompress } from './index';
 
 describe('@remusao/smaz-compress', () => {
   it('decompresses empty array', () => {

--- a/packages/smaz-decompress/tsconfig.json
+++ b/packages/smaz-decompress/tsconfig.json
@@ -5,8 +5,8 @@
     "outDir": "dist/cjs",
     "declarationDir": "dist/types"
   },
-  "include": [
-    "index.ts",
-    "index.test.ts"
+  "files": [
+    "./index.ts",
+    "./index.test.ts"
   ]
 }

--- a/packages/smaz-generate/index.test.ts
+++ b/packages/smaz-generate/index.test.ts
@@ -3,7 +3,7 @@ import 'mocha';
 
 import { Smaz } from '@remusao/smaz';
 
-import { generate, Builder } from '.';
+import { generate, Builder } from './index';
 
 describe('@remusao/smaz-generate', () => {
   describe('#Builder', () => {

--- a/packages/smaz-generate/tsconfig.json
+++ b/packages/smaz-generate/tsconfig.json
@@ -10,8 +10,8 @@
     { "path": "../smaz-compress/tsconfig.json" },
     { "path": "../smaz/tsconfig.json" }
   ],
-  "include": [
-    "index.ts",
-    "index.test.ts"
+  "files": [
+    "./index.ts",
+    "./index.test.ts"
   ]
 }

--- a/packages/smaz/index.test.ts
+++ b/packages/smaz/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { compress, decompress, getCompressedSize } from '.';
+import { compress, decompress, getCompressedSize } from './index';
 
 describe('@remusao/smaz', () => {
   [

--- a/packages/smaz/tsconfig.json
+++ b/packages/smaz/tsconfig.json
@@ -9,8 +9,8 @@
     { "path": "../smaz-compress/tsconfig.json" },
     { "path": "../smaz-decompress/tsconfig.json" }
   ],
-  "include": [
-    "index.ts",
-    "index.test.ts"
+  "files": [
+    "./index.ts",
+    "./index.test.ts"
   ]
 }

--- a/packages/thunderbird-msg-filters/index.test.ts
+++ b/packages/thunderbird-msg-filters/index.test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import { parse, format } from '.';
+import { parse, format } from './index';
 
 describe('@remusao/thunderbird-msg-filters', () => {
   it('pretty-print like original', () => {

--- a/packages/trie/index.test.ts
+++ b/packages/trie/index.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { create, lookup } from '.';
+import { create, lookup } from './index';
 
 describe('@remusao/trie', () => {
   describe('#create', () => {
     it('empty trie', () => {
       const trie = create([]);
       expect(trie.code).to.be.undefined;
-      expect(trie.chars).to.have.length(128);
+      expect(trie.chars).to.have.length(0);
       expect(lookup(trie, '')).to.be.false;
       expect(lookup(trie, 'foo')).to.be.false;
     });

--- a/packages/trie/index.ts
+++ b/packages/trie/index.ts
@@ -1,141 +1,12 @@
 
 export interface Trie {
-  chars: (undefined | Trie)[];
+  chars: Map<number, Trie>;
   code: number | undefined;
 }
 
 function newNode(): Trie {
   return {
-    chars: [
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    ],
+    chars: new Map(),
     code: undefined,
   };
 }
@@ -147,10 +18,10 @@ export function create(strings: readonly string[]): Trie {
     let root = node;
     for (let j = 0; j < tok.length; j += 1) {
       const c = tok.charCodeAt(j);
-      let next = root.chars[c];
+      let next = root.chars.get(c);
       if (next === undefined) {
         next = newNode();
-        root.chars[c] = next;
+        root.chars.set(c, next);
       }
       root = next;
     }
@@ -166,7 +37,7 @@ export function lookup(trie: Trie, str: string): boolean {
       return false;
     }
 
-    node = node.chars[str.charCodeAt(i)];
+    node = node.chars.get(str.charCodeAt(i));
   }
 
   return node !== undefined && node.code  !== undefined;

--- a/packages/trie/tsconfig.json
+++ b/packages/trie/tsconfig.json
@@ -5,8 +5,8 @@
     "outDir": "dist/cjs",
     "declarationDir": "dist/types"
   },
-  "include": [
-    "index.ts",
-    "index.test.ts"
+  "files": [
+    "./index.ts",
+    "./index.test.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,5 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true
-  },
-  "exclude": [
-    "node_modules"
-  ]
+  }
 }


### PR DESCRIPTION
Using dense arrays for each level of the trie yields best performance, but comes at the cost of increased memory usage (e.g. it was observed that one instance of smaz can eat up to 1.7 MB of memory as seen in dev tools). This PR reverts back to a sparse `Map<number, Trie>` instead, which incurs a slight drop of compression speed (68 MB/s -> 56 MB/s).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @remusao/auto-config@1.2.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  npm install @remusao/counter@1.2.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  npm install @remusao/smaz-compress@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  npm install @remusao/smaz-decompress@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  npm install @remusao/smaz-generate@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  npm install @remusao/smaz@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  npm install @remusao/thunderbird-msg-filters@1.4.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  npm install @remusao/trie@1.3.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  # or 
  yarn add @remusao/auto-config@1.2.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  yarn add @remusao/counter@1.2.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  yarn add @remusao/smaz-compress@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  yarn add @remusao/smaz-decompress@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  yarn add @remusao/smaz-generate@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  yarn add @remusao/smaz@1.8.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  yarn add @remusao/thunderbird-msg-filters@1.4.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  yarn add @remusao/trie@1.3.0-canary.21.fa10bd68e2b27002b4b08bc4b46c0b54f45a8fa1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
