### PR TITLE
Fine-tune url type detection

### DIFF
--- a/packages/guess-url-type/index.ts
+++ b/packages/guess-url-type/index.ts
@@ -74,7 +74,7 @@ export default function getRequestType(url: string): RequestType {
     url.startsWith('data:text/html') ||
     url.startsWith('data:application/xhtml') ||
     url.startsWith('https://www.youtube.com/embed/') ||
-    url === 'https://www.google.ie/gen_204'
+    url.startsWith('https://www.google.com/gen_204')
   ) {
     return 'document';
   }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @remusao/guess-url-type@1.1.2-canary.116.6612af29bc71ff139e93c383c9f7408d1083846d.0
  # or 
  yarn add @remusao/guess-url-type@1.1.2-canary.116.6612af29bc71ff139e93c383c9f7408d1083846d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
