### PR TITLE
Badge rotation should only trigger if tab is active

### DIFF
--- a/packages/badger/README.md
+++ b/packages/badger/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```javascript
-const { Badger } = require('@remusao/badger');
+const { Badge } = require('@remusao/badger');
 
 const badge = new Badge({
   // Optionally customize badge text and background colors.

--- a/packages/badger/index.ts
+++ b/packages/badger/index.ts
@@ -95,7 +95,11 @@ export class Badge {
 
   public incr(tabId: number): void {
     this.counter.set(tabId, (this.counter.get(tabId) || 0) + 1);
-    this.startUpdatingBadge();
+
+    // Only start animation if increment happened on currently active tab
+    if (tabId === this.activeTabId) {
+      this.startUpdatingBadge();
+    }
   }
 
   public reset(tabId: number): void {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @remusao/badger@1.1.3-canary.181.5bf6bb77ceb64186c4cb4a5c67f1c9f06e114d0d.0
  # or 
  yarn add @remusao/badger@1.1.3-canary.181.5bf6bb77ceb64186c4cb4a5c67f1c9f06e114d0d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
