### PR TITLE
feat(smaz-compress): accept ui8 array

### DIFF
--- a/packages/smaz-compress/src/index.ts
+++ b/packages/smaz-compress/src/index.ts
@@ -13,22 +13,32 @@ export class SmazCompress {
     this.verbatim = new Uint8Array(255);
   }
 
-  public getCompressedSize(str: string): number {
+  public getCompressedSize(str: string | Uint8Array): number {
     if (str.length === 0) {
       return 0;
+    }
+
+    let data: Uint8Array;
+    if (typeof str === 'string') {
+      data = new Uint8Array(str.length);
+      for (let i = 0; i < str.length; i++) {
+        data[i] = str.charCodeAt(i);
+      }
+    } else {
+      data = str;
     }
 
     let bufferIndex = 0;
     let verbatimIndex = 0;
     let inputIndex = 0;
 
-    while (inputIndex < str.length) {
+    while (inputIndex < data.length) {
       let indexAfterMatch = -1;
       let code = -1;
       let root: Trie | undefined = this.trie;
 
       for (let j = inputIndex; j < str.length; j += 1) {
-        root = root.chars.get(str.charCodeAt(j));
+        root = root.chars.get(data[j]);
         if (root === undefined) {
           break;
         }
@@ -64,23 +74,32 @@ export class SmazCompress {
     return bufferIndex;
   }
 
-  public compress(str: string): Uint8Array {
+  public compress(str: string | Uint8Array): Uint8Array {
     if (str.length === 0) {
       return EMPTY_UINT8_ARRAY;
+    }
+
+    let data: Uint8Array;
+    if (typeof str === 'string') {
+      data = new Uint8Array(str.length);
+      for (let i = 0; i < str.length; i++) {
+        data[i] = str.charCodeAt(i);
+      }
+    } else {
+      data = str;
     }
 
     let bufferIndex = 0;
     let verbatimIndex = 0;
     let inputIndex = 0;
-    const len = str.length;
 
-    while (inputIndex < str.length) {
+    while (inputIndex < data.length) {
       let indexAfterMatch = -1;
       let code = -1;
       let root: Trie | undefined = this.trie;
 
-      for (let j = inputIndex; j < len; j += 1) {
-        root = root.chars.get(str.charCodeAt(j));
+      for (let j = inputIndex; j < data.length; j += 1) {
+        root = root.chars.get(data[j]);
         if (root === undefined) {
           break;
         }
@@ -92,7 +111,7 @@ export class SmazCompress {
       }
 
       if (code === -1) {
-        this.verbatim[verbatimIndex++] = str.charCodeAt(inputIndex++);
+        this.verbatim[verbatimIndex++] = data[inputIndex++];
         if (verbatimIndex === 255) {
           bufferIndex = this.flushVerbatim(verbatimIndex, bufferIndex);
           verbatimIndex = 0;

--- a/packages/smaz-compress/src/index.ts
+++ b/packages/smaz-compress/src/index.ts
@@ -20,8 +20,8 @@ export class SmazCompress {
 
     const retrieve =
       typeof str === 'string'
-        ? str.charCodeAt.bind(str)
-        : (str.at.bind(str) as (i: number) => number);
+        ? (idx: number): number => str.charCodeAt(idx)
+        : (idx: number): number => str[idx];
 
     let bufferIndex = 0;
     let verbatimIndex = 0;

--- a/packages/smaz-compress/src/index.ts
+++ b/packages/smaz-compress/src/index.ts
@@ -18,7 +18,10 @@ export class SmazCompress {
       return 0;
     }
 
-    const retrieve = typeof str === 'string' ? str.charCodeAt.bind(str) : str.at.bind(str) as (i: number) => number;
+    const retrieve =
+      typeof str === 'string'
+        ? str.charCodeAt.bind(str)
+        : (str.at.bind(str) as (i: number) => number);
 
     let bufferIndex = 0;
     let verbatimIndex = 0;
@@ -71,7 +74,10 @@ export class SmazCompress {
       return EMPTY_UINT8_ARRAY;
     }
 
-    const retrieve = typeof str === 'string' ? str.charCodeAt.bind(str) : str.at.bind(str) as (i: number) => number;
+    const retrieve =
+      typeof str === 'string'
+        ? str.charCodeAt.bind(str)
+        : (str.at.bind(str) as (i: number) => number);
 
     let bufferIndex = 0;
     let verbatimIndex = 0;

--- a/packages/smaz-compress/src/index.ts
+++ b/packages/smaz-compress/src/index.ts
@@ -18,27 +18,19 @@ export class SmazCompress {
       return 0;
     }
 
-    let data: Uint8Array;
-    if (typeof str === 'string') {
-      data = new Uint8Array(str.length);
-      for (let i = 0; i < str.length; i++) {
-        data[i] = str.charCodeAt(i);
-      }
-    } else {
-      data = str;
-    }
+    const retrieve = typeof str === 'string' ? str.charCodeAt.bind(str) : str.at.bind(str) as (i: number) => number;
 
     let bufferIndex = 0;
     let verbatimIndex = 0;
     let inputIndex = 0;
 
-    while (inputIndex < data.length) {
+    while (inputIndex < str.length) {
       let indexAfterMatch = -1;
       let code = -1;
       let root: Trie | undefined = this.trie;
 
       for (let j = inputIndex; j < str.length; j += 1) {
-        root = root.chars.get(data[j]);
+        root = root.chars.get(retrieve(j));
         if (root === undefined) {
           break;
         }

--- a/packages/smaz-compress/src/index.ts
+++ b/packages/smaz-compress/src/index.ts
@@ -13,26 +13,26 @@ export class SmazCompress {
     this.verbatim = new Uint8Array(255);
   }
 
-  public getCompressedSize(str: string | Uint8Array): number {
-    if (str.length === 0) {
+  public getCompressedSize(buffer: string | Uint8Array): number {
+    if (buffer.length === 0) {
       return 0;
     }
 
     const retrieve =
-      typeof str === 'string'
-        ? (idx: number): number => str.charCodeAt(idx)
-        : (idx: number): number => str[idx];
+      typeof buffer === 'string'
+        ? (idx: number): number => buffer.charCodeAt(idx)
+        : (idx: number): number => buffer[idx];
 
     let bufferIndex = 0;
     let verbatimIndex = 0;
     let inputIndex = 0;
 
-    while (inputIndex < str.length) {
+    while (inputIndex < buffer.length) {
       let indexAfterMatch = -1;
       let code = -1;
       let root: Trie | undefined = this.trie;
 
-      for (let j = inputIndex; j < str.length; j += 1) {
+      for (let j = inputIndex; j < buffer.length; j += 1) {
         root = root.chars.get(retrieve(j));
         if (root === undefined) {
           break;
@@ -69,26 +69,26 @@ export class SmazCompress {
     return bufferIndex;
   }
 
-  public compress(str: string | Uint8Array): Uint8Array {
-    if (str.length === 0) {
+  public compress(buffer: string | Uint8Array): Uint8Array {
+    if (buffer.length === 0) {
       return EMPTY_UINT8_ARRAY;
     }
 
     const retrieve =
-      typeof str === 'string'
-        ? str.charCodeAt.bind(str)
-        : (str.at.bind(str) as (i: number) => number);
+      typeof buffer === 'string'
+        ? (idx: number): number => buffer.charCodeAt(idx)
+        : (idx: number): number => buffer[idx];
 
     let bufferIndex = 0;
     let verbatimIndex = 0;
     let inputIndex = 0;
 
-    while (inputIndex < str.length) {
+    while (inputIndex < buffer.length) {
       let indexAfterMatch = -1;
       let code = -1;
       let root: Trie | undefined = this.trie;
 
-      for (let j = inputIndex; j < str.length; j += 1) {
+      for (let j = inputIndex; j < buffer.length; j += 1) {
         root = root.chars.get(retrieve(j));
         if (root === undefined) {
           break;

--- a/packages/smaz-compress/src/index.ts
+++ b/packages/smaz-compress/src/index.ts
@@ -79,27 +79,19 @@ export class SmazCompress {
       return EMPTY_UINT8_ARRAY;
     }
 
-    let data: Uint8Array;
-    if (typeof str === 'string') {
-      data = new Uint8Array(str.length);
-      for (let i = 0; i < str.length; i++) {
-        data[i] = str.charCodeAt(i);
-      }
-    } else {
-      data = str;
-    }
+    const retrieve = typeof str === 'string' ? str.charCodeAt.bind(str) : str.at.bind(str) as (i: number) => number;
 
     let bufferIndex = 0;
     let verbatimIndex = 0;
     let inputIndex = 0;
 
-    while (inputIndex < data.length) {
+    while (inputIndex < str.length) {
       let indexAfterMatch = -1;
       let code = -1;
       let root: Trie | undefined = this.trie;
 
-      for (let j = inputIndex; j < data.length; j += 1) {
-        root = root.chars.get(data[j]);
+      for (let j = inputIndex; j < str.length; j += 1) {
+        root = root.chars.get(retrieve(j));
         if (root === undefined) {
           break;
         }
@@ -111,7 +103,7 @@ export class SmazCompress {
       }
 
       if (code === -1) {
-        this.verbatim[verbatimIndex++] = data[inputIndex++];
+        this.verbatim[verbatimIndex++] = retrieve(inputIndex++);
         if (verbatimIndex === 255) {
           bufferIndex = this.flushVerbatim(verbatimIndex, bufferIndex);
           verbatimIndex = 0;

--- a/packages/smaz-compress/test/index.test.ts
+++ b/packages/smaz-compress/test/index.test.ts
@@ -112,12 +112,16 @@ describe('@remusao/smaz-compress', () => {
     const smaz = new SmazCompress(['foo']);
     const text = '한글';
     const utf8 = new TextEncoder().encode(text);
-    expect(smaz.compress(new Uint8Array([
-      ...utf8,
-      'f'.charCodeAt(0),
-      'o'.charCodeAt(0),
-      'o'.charCodeAt(0),
-    ]))).to.deep.equal(
+    expect(
+      smaz.compress(
+        new Uint8Array([
+          ...utf8,
+          'f'.charCodeAt(0),
+          'o'.charCodeAt(0),
+          'o'.charCodeAt(0),
+        ]),
+      ),
+    ).to.deep.equal(
       new Uint8Array([
         255,
         utf8.byteLength,

--- a/packages/smaz-compress/test/index.test.ts
+++ b/packages/smaz-compress/test/index.test.ts
@@ -107,4 +107,23 @@ describe('@remusao/smaz-compress', () => {
     const compressed = smaz.compress(str);
     expect(compressed.length).to.be.eql(smaz.getCompressedSize(str));
   });
+
+  it('compresses Uint8Array with unicode', () => {
+    const smaz = new SmazCompress(['foo']);
+    const text = '한글';
+    const utf8 = new TextEncoder().encode(text);
+    expect(smaz.compress(new Uint8Array([
+      ...utf8,
+      'f'.charCodeAt(0),
+      'o'.charCodeAt(0),
+      'o'.charCodeAt(0),
+    ]))).to.deep.equal(
+      new Uint8Array([
+        255,
+        utf8.byteLength,
+        ...utf8,
+        0, // 'foo'
+      ]),
+    );
+  });
 });

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -31,6 +31,14 @@ const EMPTY_UINT8_ARRAY = new Uint8Array(0);
 const TEXT_ENCODER = new TextEncoder();
 
 export class SmazDecompressRaw {
+  /**
+   * Initialize `SmazDecompressRaw` with a codebook with strings.
+   * We use `TextEncoder` which encodes into utf8 to handle unicode characters such as '🥳'.
+   * If you rely on a different encoding, you should pass encoded codebook to constructor
+   * we don't distinguish the codebook chunk of the output from `decompress` method.
+   * If you mix other encodings in the buffer while relying on this method, you need to
+   * detect utf8 signatures and handle them separately, which is also not guaranteed.
+   */
   public static fromStringCodebook(codebook: readonly string[]) {
     return new this(codebook.map((str) => TEXT_ENCODER.encode(str)));
   }

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -27,26 +27,19 @@ export class SmazDecompress {
   }
 }
 
+const EMPTY_UINT8_ARRAY = new Uint8Array(0);
+const TEXT_ENCODER = new TextEncoder();
+
 export class SmazDecompressRaw {
   public static fromStringCodebook(codebook: readonly string[]) {
-    return new this(
-      codebook.map((str) => {
-        const arr = new Uint8Array(str.length);
-        for (let i = 0; i < arr.length; i++) {
-          arr[i] = str.charCodeAt(i);
-        }
-        return arr;
-      }),
-    );
+    return new this(codebook.map((str) => TEXT_ENCODER.encode(str)));
   }
-
-  private EMPTY_UINT8_ARRAY = new Uint8Array(0);
 
   constructor(private readonly codebook: readonly Uint8Array[]) {}
 
   public decompress(arr: Uint8Array): Uint8Array {
     if (arr.byteLength === 0) {
-      return this.EMPTY_UINT8_ARRAY;
+      return EMPTY_UINT8_ARRAY;
     }
 
     const chunks: Uint8Array[] = [];

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -29,19 +29,20 @@ export class SmazDecompress {
 
 export class SmazDecompressRaw {
   public static fromStringCodebook(codebook: readonly string[]) {
-    return new this(codebook.map(str => {
-      const arr = new Uint8Array(str.length);
-      for (let i = 0; i < arr.length; i++) {
-        arr[i] = str.charCodeAt(i);
-      }
-      return arr;
-    }));
+    return new this(
+      codebook.map((str) => {
+        const arr = new Uint8Array(str.length);
+        for (let i = 0; i < arr.length; i++) {
+          arr[i] = str.charCodeAt(i);
+        }
+        return arr;
+      }),
+    );
   }
 
   private EMPTY_UINT8_ARRAY = new Uint8Array(0);
 
-  constructor(private readonly codebook: readonly Uint8Array[]) {
-  }
+  constructor(private readonly codebook: readonly Uint8Array[]) {}
 
   public decompress(arr: Uint8Array): Uint8Array {
     if (arr.byteLength === 0) {
@@ -65,7 +66,9 @@ export class SmazDecompressRaw {
       }
     }
 
-    const output = new Uint8Array(chunks.reduce((state, chunk) => state + chunk.byteLength, 0));
+    const output = new Uint8Array(
+      chunks.reduce((state, chunk) => state + chunk.byteLength, 0),
+    );
     for (let j = 0, offset = 0; j < chunks.length; j++) {
       output.set(chunks[j], offset);
       offset += chunks[j].byteLength;

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -39,7 +39,8 @@ export class SmazDecompressRaw {
    * detect utf8 signatures and handle them separately, which is also not guaranteed.
    */
   public static fromStringCodebook(codebook: readonly string[]) {
-    return new this(codebook.map((str) => new TextEncoder().encode(str)));
+    const TEXT_ENCODER = new TextEncoder();
+    return new this(codebook.map((str) => TEXT_ENCODER.encode(str)));
   }
 
   constructor(private readonly codebook: readonly Uint8Array[]) {}

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -28,7 +28,6 @@ export class SmazDecompress {
 }
 
 const EMPTY_UINT8_ARRAY = new Uint8Array(0);
-const TEXT_ENCODER = new TextEncoder();
 
 export class SmazDecompressRaw {
   /**
@@ -40,7 +39,7 @@ export class SmazDecompressRaw {
    * detect utf8 signatures and handle them separately, which is also not guaranteed.
    */
   public static fromStringCodebook(codebook: readonly string[]) {
-    return new this(codebook.map((str) => TEXT_ENCODER.encode(str)));
+    return new this(codebook.map((str) => new TextEncoder().encode(str)));
   }
 
   constructor(private readonly codebook: readonly Uint8Array[]) {}

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -26,3 +26,51 @@ export class SmazDecompress {
     return output;
   }
 }
+
+export class SmazDecompressRaw {
+  public static fromStringCodebook(codebook: readonly string[]) {
+    return new this(codebook.map(str => {
+      const arr = new Uint8Array(str.length);
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = str.charCodeAt(i);
+      }
+      return arr;
+    }));
+  }
+
+  private EMPTY_UINT8_ARRAY = new Uint8Array(0);
+
+  constructor(private readonly codebook: readonly Uint8Array[]) {
+  }
+
+  public decompress(arr: Uint8Array): Uint8Array {
+    if (arr.byteLength === 0) {
+      return this.EMPTY_UINT8_ARRAY;
+    }
+
+    const chunks: Uint8Array[] = [];
+    let i = 0;
+
+    while (i < arr.byteLength) {
+      if (arr[i] === 254) {
+        chunks.push(arr.subarray(i + 1, i + 2));
+        i += 2;
+      } else if (arr[i] === 255) {
+        const stop = i + arr[i + 1] + 2;
+        chunks.push(arr.subarray(i + 2, stop));
+        i = stop;
+      } else {
+        chunks.push(this.codebook[arr[i]]);
+        i += 1;
+      }
+    }
+
+    const output = new Uint8Array(chunks.reduce((state, chunk) => state + chunk.byteLength, 0));
+    for (let j = 0, offset = 0; j < chunks.length; j++) {
+      output.set(chunks[j], offset);
+      offset += chunks[j].byteLength;
+    }
+
+    return output;
+  }
+}

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -15,9 +15,9 @@ export class SmazDecompress {
         i += 2;
       } else if (arr[i] === 255) {
         const stop = i + arr[i + 1] + 2;
-        output += new TextDecoder('utf8', { ignoreBOM: true })
-          .decode(arr.slice(i + 2, stop));
-        i = stop;
+        for (i += 2; i < stop; i += 1) {
+          output += String.fromCharCode(arr[i]);
+        }
       } else {
         output += this.codebook[arr[i]];
         i += 1;

--- a/packages/smaz-decompress/src/index.ts
+++ b/packages/smaz-decompress/src/index.ts
@@ -15,9 +15,9 @@ export class SmazDecompress {
         i += 2;
       } else if (arr[i] === 255) {
         const stop = i + arr[i + 1] + 2;
-        for (i += 2; i < stop; i += 1) {
-          output += String.fromCharCode(arr[i]);
-        }
+        output += new TextDecoder('utf8', { ignoreBOM: true })
+          .decode(arr.slice(i + 2, stop));
+        i = stop;
       } else {
         output += this.codebook[arr[i]];
         i += 1;

--- a/packages/smaz-decompress/test/index.test.ts
+++ b/packages/smaz-decompress/test/index.test.ts
@@ -57,7 +57,7 @@ describe('@remusao/smaz-compress', () => {
 
   it('decompresses a utf8 container', () => {
     const smaz = SmazDecompressRaw.fromStringCodebook(['foo']);
-    const text = '한글'
+    const text = '한글';
     const utf8 = new TextEncoder().encode(text);
     const decompressed = smaz.decompress(
       new Uint8Array([
@@ -67,6 +67,8 @@ describe('@remusao/smaz-compress', () => {
         0, // 'foo'
       ]),
     );
-    expect(new TextDecoder('utf8', { ignoreBOM: true }).decode(decompressed)).to.equal(`${text}foo`);
+    expect(
+      new TextDecoder('utf8', { ignoreBOM: true }).decode(decompressed),
+    ).to.equal(`${text}foo`);
   });
 });

--- a/packages/smaz-decompress/test/index.test.ts
+++ b/packages/smaz-decompress/test/index.test.ts
@@ -4,71 +4,92 @@ import 'mocha';
 import { SmazDecompress, SmazDecompressRaw } from '../src/index.js';
 
 describe('@remusao/smaz-compress', () => {
-  it('decompresses empty array', () => {
-    const smaz = new SmazDecompress(['foo']);
-    expect(smaz.decompress(new Uint8Array(0))).to.equal('');
+  context('SmazDecompress', () => {
+    it('decompresses empty array', () => {
+      const smaz = new SmazDecompress(['foo']);
+      expect(smaz.decompress(new Uint8Array(0))).to.equal('');
+    });
+
+    it('decompresses string from codebook', () => {
+      const smaz = new SmazDecompress(['foo']);
+      expect(smaz.decompress(new Uint8Array([0]))).to.equal('foo');
+    });
+
+    it('decompresses verbatim character', () => {
+      const smaz = new SmazDecompress(['foo']);
+      expect(
+        smaz.decompress(new Uint8Array([254, 'b'.charCodeAt(0)])),
+      ).to.equal('b');
+    });
+
+    it('decompresses verbatim string', () => {
+      const smaz = new SmazDecompress(['foo']);
+      expect(
+        smaz.decompress(
+          new Uint8Array([
+            255,
+            3,
+            'b'.charCodeAt(0),
+            'a'.charCodeAt(0),
+            'r'.charCodeAt(0),
+          ]),
+        ),
+      ).to.equal('bar');
+    });
+
+    it('decompresses a mix', () => {
+      const smaz = new SmazDecompress(['foo', 'baz']);
+      expect(
+        smaz.decompress(
+          new Uint8Array([
+            254,
+            'b'.charCodeAt(0),
+            0, // 'foo'
+            1, // 'baz'
+            255,
+            3,
+            'b'.charCodeAt(0),
+            'a'.charCodeAt(0),
+            'r'.charCodeAt(0),
+          ]),
+        ),
+      ).to.equal('bfoobazbar');
+    });
   });
 
-  it('decompresses string from codebook', () => {
-    const smaz = new SmazDecompress(['foo']);
-    expect(smaz.decompress(new Uint8Array([0]))).to.equal('foo');
-  });
-
-  it('decompresses verbatim character', () => {
-    const smaz = new SmazDecompress(['foo']);
-    expect(smaz.decompress(new Uint8Array([254, 'b'.charCodeAt(0)]))).to.equal(
-      'b',
-    );
-  });
-
-  it('decompresses verbatim string', () => {
-    const smaz = new SmazDecompress(['foo']);
-    expect(
-      smaz.decompress(
+  context('SmazDecompressRaw', () => {
+    it('decompresses a utf8 container', () => {
+      const smaz = SmazDecompressRaw.fromStringCodebook(['foo']);
+      const text = '한글';
+      const utf8 = new TextEncoder().encode(text);
+      const decompressed = smaz.decompress(
         new Uint8Array([
           255,
-          3,
-          'b'.charCodeAt(0),
-          'a'.charCodeAt(0),
-          'r'.charCodeAt(0),
-        ]),
-      ),
-    ).to.equal('bar');
-  });
-
-  it('decompresses a mix', () => {
-    const smaz = new SmazDecompress(['foo', 'baz']);
-    expect(
-      smaz.decompress(
-        new Uint8Array([
-          254,
-          'b'.charCodeAt(0),
+          utf8.byteLength,
+          ...utf8,
           0, // 'foo'
-          1, // 'baz'
-          255,
-          3,
-          'b'.charCodeAt(0),
-          'a'.charCodeAt(0),
-          'r'.charCodeAt(0),
         ]),
-      ),
-    ).to.equal('bfoobazbar');
-  });
+      );
+      expect(
+        new TextDecoder('utf8', { ignoreBOM: true }).decode(decompressed),
+      ).to.equal(`${text}foo`);
+    });
 
-  it('decompresses a utf8 container', () => {
-    const smaz = SmazDecompressRaw.fromStringCodebook(['foo']);
-    const text = '한글';
-    const utf8 = new TextEncoder().encode(text);
-    const decompressed = smaz.decompress(
-      new Uint8Array([
-        255,
-        utf8.byteLength,
-        ...utf8,
-        0, // 'foo'
-      ]),
-    );
-    expect(
-      new TextDecoder('utf8', { ignoreBOM: true }).decode(decompressed),
-    ).to.equal(`${text}foo`);
+    it('decompresses with unicode codebook', () => {
+      const smaz = SmazDecompressRaw.fromStringCodebook(['🥳']);
+      const utf8 = new TextEncoder().encode('🥳');
+      const decompressed = smaz.decompress(
+        new Uint8Array([
+          255,
+          utf8.byteLength,
+          ...utf8,
+          254,
+          65, // 'A'
+        ]),
+      );
+      expect(
+        new TextDecoder('utf8', { ignoreBOM: true }).decode(decompressed),
+      ).to.equal(`🥳A`);
+    });
   });
 });

--- a/packages/smaz-decompress/test/index.test.ts
+++ b/packages/smaz-decompress/test/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { SmazDecompress } from '../src/index.js';
+import { SmazDecompress, SmazDecompressRaw } from '../src/index.js';
 
 describe('@remusao/smaz-compress', () => {
   it('decompresses empty array', () => {
@@ -53,5 +53,20 @@ describe('@remusao/smaz-compress', () => {
         ]),
       ),
     ).to.equal('bfoobazbar');
+  });
+
+  it('decompresses a utf8 container', () => {
+    const smaz = SmazDecompressRaw.fromStringCodebook(['foo']);
+    const text = '한글'
+    const utf8 = new TextEncoder().encode(text);
+    const decompressed = smaz.decompress(
+      new Uint8Array([
+        255,
+        utf8.byteLength,
+        ...utf8,
+        0, // 'foo'
+      ]),
+    );
+    expect(new TextDecoder('utf8', { ignoreBOM: true }).decode(decompressed)).to.equal(`${text}foo`);
   });
 });

--- a/packages/smaz/README.md
+++ b/packages/smaz/README.md
@@ -30,3 +30,11 @@ const { compress, decompress } = require('@remusao/smaz');
 const compressed = compress('foobar');
 console.log(decompress(compressed));
 ```
+
+With encoding:
+```javascript
+const { compress, decompressRaw } = require('@remusao/smaz');
+
+const compressed = compress(new TextEncoder().encode('foobar'));
+console.log(new TextDecoder('utf8').decode(decompressRaw(compressed)));
+```

--- a/packages/smaz/src/index.ts
+++ b/packages/smaz/src/index.ts
@@ -13,11 +13,11 @@ export class Smaz {
     this.decompressor = new SmazDecompress(codebook);
   }
 
-  public compress(str: string): Uint8Array {
+  public compress(str: string | Uint8Array): Uint8Array {
     return this.compressor.compress(str);
   }
 
-  public getCompressedSize(str: string): number {
+  public getCompressedSize(str: string | Uint8Array): number {
     return this.compressor.getCompressedSize(str);
   }
 
@@ -45,10 +45,10 @@ export function decompress(array: Uint8Array): string {
   return getDefaultSmaz().decompress(array);
 }
 
-export function compress(str: string): Uint8Array {
+export function compress(str: string | Uint8Array): Uint8Array {
   return getDefaultSmaz().compress(str);
 }
 
-export function getCompressedSize(str: string): number {
+export function getCompressedSize(str: string | Uint8Array): number {
   return getDefaultSmaz().getCompressedSize(str);
 }

--- a/packages/smaz/src/index.ts
+++ b/packages/smaz/src/index.ts
@@ -15,12 +15,12 @@ export class Smaz {
     this.rawDecompressor = SmazDecompressRaw.fromStringCodebook(codebook);
   }
 
-  public compress(str: string | Uint8Array): Uint8Array {
-    return this.compressor.compress(str);
+  public compress(buffer: string | Uint8Array): Uint8Array {
+    return this.compressor.compress(buffer);
   }
 
-  public getCompressedSize(str: string | Uint8Array): number {
-    return this.compressor.getCompressedSize(str);
+  public getCompressedSize(buffer: string | Uint8Array): number {
+    return this.compressor.getCompressedSize(buffer);
   }
 
   public decompress(buffer: Uint8Array): string {
@@ -55,10 +55,10 @@ export function decompressRaw(array: Uint8Array): Uint8Array {
   return getDefaultSmaz().decompressRaw(array);
 }
 
-export function compress(str: string | Uint8Array): Uint8Array {
-  return getDefaultSmaz().compress(str);
+export function compress(buffer: string | Uint8Array): Uint8Array {
+  return getDefaultSmaz().compress(buffer);
 }
 
-export function getCompressedSize(str: string | Uint8Array): number {
-  return getDefaultSmaz().getCompressedSize(str);
+export function getCompressedSize(buffer: string | Uint8Array): number {
+  return getDefaultSmaz().getCompressedSize(buffer);
 }

--- a/packages/smaz/src/index.ts
+++ b/packages/smaz/src/index.ts
@@ -1,9 +1,10 @@
 import { SmazCompress } from '@remusao/smaz-compress';
-import { SmazDecompress } from '@remusao/smaz-decompress';
+import { SmazDecompress, SmazDecompressRaw } from '@remusao/smaz-decompress';
 
 export class Smaz {
   private readonly compressor: SmazCompress;
   private readonly decompressor: SmazDecompress;
+  private readonly rawDecompressor: SmazDecompressRaw;
 
   constructor(
     readonly codebook: readonly string[],
@@ -11,6 +12,7 @@ export class Smaz {
   ) {
     this.compressor = new SmazCompress(codebook, maxSize);
     this.decompressor = new SmazDecompress(codebook);
+    this.rawDecompressor = SmazDecompressRaw.fromStringCodebook(codebook);
   }
 
   public compress(str: string | Uint8Array): Uint8Array {
@@ -23,6 +25,10 @@ export class Smaz {
 
   public decompress(buffer: Uint8Array): string {
     return this.decompressor.decompress(buffer);
+  }
+
+  public decompressRaw(buffer: Uint8Array): Uint8Array {
+    return this.rawDecompressor.decompress(buffer);
   }
 }
 
@@ -43,6 +49,10 @@ function getDefaultSmaz(): Smaz {
 
 export function decompress(array: Uint8Array): string {
   return getDefaultSmaz().decompress(array);
+}
+
+export function decompressRaw(array: Uint8Array): Uint8Array {
+  return getDefaultSmaz().decompressRaw(array);
 }
 
 export function compress(str: string | Uint8Array): Uint8Array {

--- a/packages/smaz/test/index.test.ts
+++ b/packages/smaz/test/index.test.ts
@@ -27,4 +27,17 @@ describe('@remusao/smaz', () => {
       expect(decompress(compressed)).to.equal(str);
     });
   });
+
+  [
+    '한글',
+    '日本語',
+    '中華料理'
+  ].forEach(str => {
+    it(str, () => {
+      const encoded = new TextEncoder().encode(str);
+      const compressed = compress(encoded);
+      expect(compressed).to.have.length(getCompressedSize(encoded));
+      expect(decompress(compressed)).to.equal(str);
+    })
+  })
 });

--- a/packages/smaz/test/index.test.ts
+++ b/packages/smaz/test/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { compress, decompress, getCompressedSize } from '../src/index.js';
+import { compress, decompress, decompressRaw, getCompressedSize } from '../src/index.js';
 
 describe('@remusao/smaz', () => {
   [
@@ -28,16 +28,18 @@ describe('@remusao/smaz', () => {
     });
   });
 
-  [
-    '한글',
-    '日本語',
-    '中華料理'
-  ].forEach(str => {
-    it(str, () => {
-      const encoded = new TextEncoder().encode(str);
-      const compressed = compress(encoded);
-      expect(compressed).to.have.length(getCompressedSize(encoded));
-      expect(decompress(compressed)).to.equal(str);
+  context('utf8', () => {
+    [
+      '한글',
+      '日本語',
+      '中華料理'
+    ].forEach(str => {
+      it(str, () => {
+        const encoded = new TextEncoder().encode(str);
+        const compressed = compress(encoded);
+        expect(compressed).to.have.length(getCompressedSize(encoded));
+        expect(new TextDecoder('utf8').decode(decompressRaw(compressed))).to.equal(str);
+      })
     })
   })
 });

--- a/packages/smaz/test/index.test.ts
+++ b/packages/smaz/test/index.test.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { compress, decompress, decompressRaw, getCompressedSize } from '../src/index.js';
+import {
+  compress,
+  decompress,
+  decompressRaw,
+  getCompressedSize,
+} from '../src/index.js';
 
 describe('@remusao/smaz', () => {
   [
@@ -29,17 +34,15 @@ describe('@remusao/smaz', () => {
   });
 
   context('utf8', () => {
-    [
-      '한글',
-      '日本語',
-      '中華料理'
-    ].forEach(str => {
+    ['한글', '日本語', '中華料理'].forEach((str) => {
       it(str, () => {
         const encoded = new TextEncoder().encode(str);
         const compressed = compress(encoded);
         expect(compressed).to.have.length(getCompressedSize(encoded));
-        expect(new TextDecoder('utf8').decode(decompressRaw(compressed))).to.equal(str);
-      })
-    })
-  })
+        expect(
+          new TextDecoder('utf8').decode(decompressRaw(compressed)),
+        ).to.equal(str);
+      });
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,7 +2005,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@remusao/bench@npm:^1.2.0, @remusao/bench@workspace:packages/bench":
+"@remusao/bench@npm:^2.0.0, @remusao/bench@workspace:packages/bench":
   version: 0.0.0-use.local
   resolution: "@remusao/bench@workspace:packages/bench"
   dependencies:
@@ -2023,7 +2023,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@remusao/counter@npm:^1.4.0, @remusao/counter@workspace:packages/counter":
+"@remusao/counter@npm:^2.0.0, @remusao/counter@workspace:packages/counter":
   version: 0.0.0-use.local
   resolution: "@remusao/counter@workspace:packages/counter"
   dependencies:
@@ -2078,7 +2078,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@remusao/smaz-benchmarks@workspace:packages/smaz-benchmarks"
   dependencies:
-    "@remusao/smaz": "npm:^1.10.0"
+    "@remusao/smaz": "npm:^2.0.0"
     "@types/benchmark": "npm:^2.1.0"
     "@types/node": "npm:^20.14.10"
     benchmark: "npm:^2.1.4"
@@ -2090,11 +2090,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@remusao/smaz-compress@npm:^1.10.0, @remusao/smaz-compress@workspace:packages/smaz-compress":
+"@remusao/smaz-compress@npm:^2.0.0, @remusao/smaz-compress@workspace:packages/smaz-compress":
   version: 0.0.0-use.local
   resolution: "@remusao/smaz-compress@workspace:packages/smaz-compress"
   dependencies:
-    "@remusao/trie": "npm:^1.5.0"
+    "@remusao/trie": "npm:^2.0.0"
     "@types/chai": "npm:^4.2.8"
     "@types/mocha": "npm:^10.0.7"
     chai: "npm:^4.2.0"
@@ -2107,7 +2107,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@remusao/smaz-decompress@npm:^1.10.0, @remusao/smaz-decompress@workspace:packages/smaz-decompress":
+"@remusao/smaz-decompress@npm:^2.0.0, @remusao/smaz-decompress@workspace:packages/smaz-decompress":
   version: 0.0.0-use.local
   resolution: "@remusao/smaz-decompress@workspace:packages/smaz-decompress"
   dependencies:
@@ -2127,9 +2127,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@remusao/smaz-generate@workspace:packages/smaz-generate"
   dependencies:
-    "@remusao/counter": "npm:^1.4.0"
-    "@remusao/smaz": "npm:^1.10.0"
-    "@remusao/smaz-compress": "npm:^1.10.0"
+    "@remusao/counter": "npm:^2.0.0"
+    "@remusao/smaz": "npm:^2.0.0"
+    "@remusao/smaz-compress": "npm:^2.0.0"
     "@types/chai": "npm:^4.2.8"
     "@types/mocha": "npm:^10.0.7"
     chai: "npm:^4.2.0"
@@ -2142,12 +2142,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@remusao/smaz@npm:^1.10.0, @remusao/smaz@workspace:packages/smaz":
+"@remusao/smaz@npm:^2.0.0, @remusao/smaz@workspace:packages/smaz":
   version: 0.0.0-use.local
   resolution: "@remusao/smaz@workspace:packages/smaz"
   dependencies:
-    "@remusao/smaz-compress": "npm:^1.10.0"
-    "@remusao/smaz-decompress": "npm:^1.10.0"
+    "@remusao/smaz-compress": "npm:^2.0.0"
+    "@remusao/smaz-decompress": "npm:^2.0.0"
     "@types/chai": "npm:^4.2.8"
     "@types/mocha": "npm:^10.0.7"
     "@types/node": "npm:^20.14.10"
@@ -2180,7 +2180,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@remusao/trie@npm:^1.5.0, @remusao/trie@workspace:packages/trie":
+"@remusao/trie@npm:^2.0.0, @remusao/trie@workspace:packages/trie":
   version: 0.0.0-use.local
   resolution: "@remusao/trie@workspace:packages/trie"
   dependencies:
@@ -2200,7 +2200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@remusao/url-match-patterns@workspace:packages/url-match-patterns"
   dependencies:
-    "@remusao/bench": "npm:^1.2.0"
+    "@remusao/bench": "npm:^2.0.0"
     "@types/chai": "npm:^4.2.8"
     "@types/mocha": "npm:^10.0.7"
     "@types/node": "npm:^20.14.10"


### PR DESCRIPTION
This allows smaz-compress to accept uint8 array. This change was made to accept utf8 string as a input.

According to Wikipedia, it's safe for utf8 payload to be passed when it is valid. You need to keep in mind that `254` and `255` are reserved by Smaz algorithm and you may fail to decompress if you pass corrupted utf8 payload.

- https://en.wikipedia.org/wiki/UTF-8#Description

I'm not changing smaz-decompress since codebook is saved in string and converting them into uint8 array temporarily doesn't make sense to me. It should be done only if needed.